### PR TITLE
hushing a warning on `npm install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,25 +18,25 @@
   "dependencies": {
     "react": "15.4.2",
     "react-dom": "15.4.2",
-    "react-router": "3.0.2",
-    "react-slick": "0.14.2"
+    "react-router": "4.0.0",
+    "react-slick": "0.14.7"
   },
   "devDependencies": {
-    "babel-core": "6.23.1",
-    "babel-loader": "6.3.0",
+    "babel-core": "6.24.0",
+    "babel-loader": "6.4.1",
     "babel-plugin-transform-object-rest-spread": "6.23.0",
     "babel-preset-node7": "1.5.0",
     "babel-preset-react": "6.23.0",
     "browser-sync": "2.18.8",
-    "css-loader": "0.26.1",
-    "extract-text-webpack-plugin": "2.0.0-rc.3",
-    "file-loader": "0.10.0",
+    "css-loader": "0.27.3",
+    "extract-text-webpack-plugin": "2.1.0",
+    "file-loader": "0.10.1",
     "node-sass": "4.5.0",
-    "sass-loader": "6.0.0",
-    "style-loader": "0.13.1",
+    "sass-loader": "6.0.3",
+    "style-loader": "0.14.1",
     "tachyons": "~4.6.2",
     "webpack": "2.2.1",
-    "webpack-dev-server": "2.3.0"
+    "webpack-dev-server": "2.4.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Got the error: `npm WARN The package sass-loader is included as both a dev and production dependency.` from the latest in develop, so this hushes that warning.

A bunch of the webpack-related loaders should actually be in dev-dependencies, since all their install selections call for the `--save-dev` flag, not just the vanilla `--save`, so I went ahead and moved those too.

I also bumped all the packages, and the build still runs as expected, so ¯\_(ツ)_/¯ since i was in the file anyway....