### PR TITLE
Undo accidental react-router upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "react": "15.4.2",
     "react-dom": "15.4.2",
-    "react-router": "4.0.0",
+    "react-router": "3.0.2",
     "react-slick": "0.14.7"
   },
   "devDependencies": {


### PR DESCRIPTION
uhhh I accidentally bumped the react-router package in the last PR, and the upgrade isn't actually trivial. Rolling back means the build loads again. 🙃